### PR TITLE
Force flex-basis to be 0; avoid x-browser bugs by using a sub-pixel value

### DIFF
--- a/iron-flex-layout.html
+++ b/iron-flex-layout.html
@@ -85,9 +85,11 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     };
 
     --layout-flex: {
-      -ms-flex: 1;
+      -ms-flex: 1 1 0.000000001px;
       -webkit-flex: 1;
       flex: 1;
+      -webkit-flex-basis: 0.000000001px;
+      flex-basis: 0.000000001px;
     };
 
     --layout-flex-2: {


### PR DESCRIPTION
This re-applies a fix made to the `flex` setting of the original Polymer `layout.html` file around the time of the 0.8-preview fork that were not carried forward into what became `Polymer/polymer/src/layout.html` that became `Polymer/layout/layout.html` that became `PolymerElements/iron-flex-layout/iron-flex-layout.html`

The original fix is here, subsequently modified by the second commit:

https://github.com/Polymer/polymer/commit/08dc2dcce85b02b256dc16589507bd532bc4c023
https://github.com/Polymer/polymer/commit/3672fbe22c94bb71f532ee813c62ba9360d07038?w=1

Note that with layout properties as opposed to selectors, the positional "`auto-vertical` in `vertical layout`" configuration is not trivial to port.