### PR TITLE
Add support for iron-component-page & docs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -21,6 +21,7 @@
   },
   "devDependencies": {
     "paper-styles": "polymerelements/paper-styles#^1.0.0",
-    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0"
+    "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
+    "iron-component-page": "polymerelements/iron-component-page#^1.0.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,7 @@
     "polymer",
     "layout"
   ],
+  "main": "iron-flex-layout.html",
   "private": true,
   "license": "http://polymer.github.io/LICENSE.txt",
   "authors": [

--- a/index.html
+++ b/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE
+The complete set of authors may be found at http://polymer.github.io/AUTHORS
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS
+-->
+<html>
+<head>
+
+  <title>iron-flex-layout</title>
+  <script src="../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="../iron-component-page/iron-component-page.html">
+
+</head>
+<body>
+
+  <iron-component-page></iron-component-page>
+
+</body>
+</html>

--- a/iron-flex-layout.html
+++ b/iron-flex-layout.html
@@ -10,8 +10,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 
-<script>
-/**
+<!--
 The `<iron-flex-layout>` component provides simple ways to use [CSS flexible box layout](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Flexible_boxes), also known as flexbox. This component provides two different ways to use flexbox:
 
 1. [Layout classes](https://github.com/PolymerElements/iron-flex-layout/tree/master/classes). The layout class stylesheet provides a simple set of class-based flexbox rules. Layout classes let you specify layout properties directly in markup.
@@ -20,12 +19,10 @@ The `<iron-flex-layout>` component provides simple ways to use [CSS flexible box
 
 A complete [guide](https://elements.polymer-project.org/guides/flex-layout) to `<iron-flex-layout>` is available.
 
+@group Iron Elements
+@pseudoElement iron-flex-layout
 @demo demo/index.html
-**/
-Polymer({
-  is:'iron-flex-layout'
-});
-</script>
+-->
 
 <style>
   /* IE 10 support for HTML5 hidden attr */

--- a/iron-flex-layout.html
+++ b/iron-flex-layout.html
@@ -10,6 +10,23 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
 <link rel="import" href="../polymer/polymer.html">
 
+<script>
+/**
+The `<iron-flex-layout>` component provides simple ways to use [CSS flexible box layout](https://developer.mozilla.org/en-US/docs/Web/Guide/CSS/Flexible_boxes), also known as flexbox. This component provides two different ways to use flexbox:
+
+1. [Layout classes](https://github.com/PolymerElements/iron-flex-layout/tree/master/classes). The layout class stylesheet provides a simple set of class-based flexbox rules. Layout classes let you specify layout properties directly in markup.
+
+2. [Custom CSS mixins](https://github.com/PolymerElements/iron-flex-layout/blob/master/iron-flex-layout.html). The mixin stylesheet includes custom CSS mixins that can be applied inside a CSS rule using the `@apply` function.
+
+A complete [guide](https://elements.polymer-project.org/guides/flex-layout) to `<iron-flex-layout>` is available.
+
+@demo demo/index.html
+**/
+Polymer({
+  is:'iron-flex-layout'
+});
+</script>
+
 <style>
   /* IE 10 support for HTML5 hidden attr */
   [hidden] {


### PR DESCRIPTION
Fixes #28 #27 #17 

Navigating to iron-flex-layout on the elements catalog today renders the following page:

![screen shot 2015-09-01 at 14 14 59](https://cloud.githubusercontent.com/assets/110953/9605243/7497c29a-50b4-11e5-8c4e-9b4339a5ce1b.png)

We don't display any documentation for the element, nor do we link to the demo (which does indeed exist) or point out that a comprehensive guide is available.

This set of changes:

* Adds an iron-component-page index and dependency for it
* Adds a basic script definition for `iron-flex-layout` and minimal docs that Hydrolysis can read back. I was unable to find a way to get docs in pure `<style>` or without an element definition rendering anything, so went in this direction.
* Links up these docs to the current demo, sources for both the classes & mixins on GitHub and the guide at https://elements.polymer-project.org/guides/flex-layout. 

Which gives us the following:

Rendered docs:

![screen shot 2015-09-01 at 14 13 44](https://cloud.githubusercontent.com/assets/110953/9605326/ec58ef3e-50b4-11e5-9a24-675aa245002b.png)

Functional demo available via demo tab:

![screen shot 2015-09-01 at 14 13 51](https://cloud.githubusercontent.com/assets/110953/9605333/f6962930-50b4-11e5-8aae-973fdb0cc80b.png)
