### PR TITLE
Add missing semi-colon to `--layout-fullbleed`

### DIFF
--- a/iron-flex-layout.html
+++ b/iron-flex-layout.html
@@ -298,7 +298,7 @@ A complete [guide](https://elements.polymer-project.org/guides/flex-layout) to `
     --layout-fullbleed: {
       margin: 0;
       height: 100vh;
-    }
+    };
 
     /* fixed position */
 


### PR DESCRIPTION
Fixes https://github.com/PolymerElements/iron-flex-layout/issues/56