### PR TITLE
set min-width and min-height for flex mixins

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -26,6 +26,7 @@
     "prism-element": "PolymerElements/prism-element#^1.0.0",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
     "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
+    "test-fixture": "PolymerElements/test-fixture#^1.0.0",
     "web-component-tester": "^4.0.0"
   },
   "ignore": []

--- a/classes/iron-flex-layout.html
+++ b/classes/iron-flex-layout.html
@@ -71,6 +71,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     -ms-flex: 1 1 auto;
     -webkit-flex: 1 1 auto;
     flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
   }
 
   .flex-none {
@@ -84,72 +86,96 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     -ms-flex: 1;
     -webkit-flex: 1;
     flex: 1;
+    min-width: 0;
+    min-height: 0;
   }
 
   .flex-2 {
     -ms-flex: 2;
     -webkit-flex: 2;
     flex: 2;
+    min-width: 0;
+    min-height: 0;
   }
 
   .flex-3 {
     -ms-flex: 3;
     -webkit-flex: 3;
     flex: 3;
+    min-width: 0;
+    min-height: 0;
   }
 
   .flex-4 {
     -ms-flex: 4;
     -webkit-flex: 4;
     flex: 4;
+    min-width: 0;
+    min-height: 0;
   }
 
   .flex-5 {
     -ms-flex: 5;
     -webkit-flex: 5;
     flex: 5;
+    min-width: 0;
+    min-height: 0;
   }
 
   .flex-6 {
     -ms-flex: 6;
     -webkit-flex: 6;
     flex: 6;
+    min-width: 0;
+    min-height: 0;
   }
 
   .flex-7 {
     -ms-flex: 7;
     -webkit-flex: 7;
     flex: 7;
+    min-width: 0;
+    min-height: 0;
   }
 
   .flex-8 {
     -ms-flex: 8;
     -webkit-flex: 8;
     flex: 8;
+    min-width: 0;
+    min-height: 0;
   }
 
   .flex-9 {
     -ms-flex: 9;
     -webkit-flex: 9;
     flex: 9;
+    min-width: 0;
+    min-height: 0;
   }
 
   .flex-10 {
     -ms-flex: 10;
     -webkit-flex: 10;
     flex: 10;
+    min-width: 0;
+    min-height: 0;
   }
 
   .flex-11 {
     -ms-flex: 11;
     -webkit-flex: 11;
     flex: 11;
+    min-width: 0;
+    min-height: 0;
   }
 
   .flex-12 {
     -ms-flex: 12;
     -webkit-flex: 12;
     flex: 12;
+    min-width: 0;
+    min-height: 0;
   }
 
   /* alignment in cross axis */

--- a/classes/iron-shadow-flex-layout.html
+++ b/classes/iron-shadow-flex-layout.html
@@ -68,6 +68,8 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     -ms-flex: 1 1 auto;
     -webkit-flex: 1 1 auto;
     flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
   }
 
   html /deep/ .flex-none {
@@ -81,72 +83,96 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     -ms-flex: 1;
     -webkit-flex: 1;
     flex: 1;
+    min-width: 0;
+    min-height: 0;
   }
 
   html /deep/ .flex-2 {
     -ms-flex: 2;
     -webkit-flex: 2;
     flex: 2;
+    min-width: 0;
+    min-height: 0;
   }
 
   html /deep/ .flex-3 {
     -ms-flex: 3;
     -webkit-flex: 3;
     flex: 3;
+    min-width: 0;
+    min-height: 0;
   }
 
   html /deep/ .flex-4 {
     -ms-flex: 4;
     -webkit-flex: 4;
     flex: 4;
+    min-width: 0;
+    min-height: 0;
   }
 
   html /deep/ .flex-5 {
     -ms-flex: 5;
     -webkit-flex: 5;
     flex: 5;
+    min-width: 0;
+    min-height: 0;
   }
 
   html /deep/ .flex-6 {
     -ms-flex: 6;
     -webkit-flex: 6;
     flex: 6;
+    min-width: 0;
+    min-height: 0;
   }
 
   html /deep/ .flex-7 {
     -ms-flex: 7;
     -webkit-flex: 7;
     flex: 7;
+    min-width: 0;
+    min-height: 0;
   }
 
   html /deep/ .flex-8 {
     -ms-flex: 8;
     -webkit-flex: 8;
     flex: 8;
+    min-width: 0;
+    min-height: 0;
   }
 
   html /deep/ .flex-9 {
     -ms-flex: 9;
     -webkit-flex: 9;
     flex: 9;
+    min-width: 0;
+    min-height: 0;
   }
 
   html /deep/ .flex-10 {
     -ms-flex: 10;
     -webkit-flex: 10;
     flex: 10;
+    min-width: 0;
+    min-height: 0;
   }
 
   html /deep/ .flex-11 {
     -ms-flex: 11;
     -webkit-flex: 11;
     flex: 11;
+    min-width: 0;
+    min-height: 0;
   }
 
   html /deep/ .flex-12 {
     -ms-flex: 12;
     -webkit-flex: 12;
     flex: 12;
+    min-width: 0;
+    min-height: 0;
   }
 
   /* alignment in cross axis */

--- a/demo/index.html
+++ b/demo/index.html
@@ -88,6 +88,36 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     </demo-snippet>
   </div>
 
+  <h4>Flexible children with not-wrapping content</h4>
+  <div class="vertical-section">
+    <demo-snippet>
+      <template>
+        <style is="custom-style">
+          .flex-horizontal {
+            width: 300px;
+            @apply(--layout-horizontal);
+          }
+          .flexchild {
+            @apply(--layout-flex);
+          }
+          .text {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+          }
+        </style>
+
+        <div class="container flex-horizontal">
+          <div>one</div>
+          <div class="flexchild">
+            <div class="text">Lorem ipsum dolor sit amet, consectetur adipisicing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.</div>
+          </div>
+          <div>three</div>
+        </div>
+      </template>
+    </demo-snippet>
+  </div>
+
   <h4>Flexible children in vertical layouts</h4>
   <div class="vertical-section">
     <demo-snippet>

--- a/iron-flex-layout.html
+++ b/iron-flex-layout.html
@@ -94,6 +94,8 @@ A complete [guide](https://elements.polymer-project.org/guides/flex-layout) to `
       -ms-flex: 1 1 auto;
       -webkit-flex: 1 1 auto;
       flex: 1 1 auto;
+      min-width: 0;
+      min-height: 0;
     };
 
     --layout-flex-none: {
@@ -108,72 +110,96 @@ A complete [guide](https://elements.polymer-project.org/guides/flex-layout) to `
       flex: 1;
       -webkit-flex-basis: 0.000000001px;
       flex-basis: 0.000000001px;
+      min-width: 0;
+      min-height: 0;
     };
 
     --layout-flex-2: {
       -ms-flex: 2;
       -webkit-flex: 2;
       flex: 2;
+      min-width: 0;
+      min-height: 0;
     };
 
     --layout-flex-3: {
       -ms-flex: 3;
       -webkit-flex: 3;
       flex: 3;
+      min-width: 0;
+      min-height: 0;
     };
 
     --layout-flex-4: {
       -ms-flex: 4;
       -webkit-flex: 4;
       flex: 4;
+      min-width: 0;
+      min-height: 0;
     };
 
     --layout-flex-5: {
       -ms-flex: 5;
       -webkit-flex: 5;
       flex: 5;
+      min-width: 0;
+      min-height: 0;
     };
 
     --layout-flex-6: {
       -ms-flex: 6;
       -webkit-flex: 6;
       flex: 6;
+      min-width: 0;
+      min-height: 0;
     };
 
     --layout-flex-7: {
       -ms-flex: 7;
       -webkit-flex: 7;
       flex: 7;
+      min-width: 0;
+      min-height: 0;
     };
 
     --layout-flex-8: {
       -ms-flex: 8;
       -webkit-flex: 8;
       flex: 8;
+      min-width: 0;
+      min-height: 0;
     };
 
     --layout-flex-9: {
       -ms-flex: 9;
       -webkit-flex: 9;
       flex: 9;
+      min-width: 0;
+      min-height: 0;
     };
 
     --layout-flex-10: {
       -ms-flex: 10;
       -webkit-flex: 10;
       flex: 10;
+      min-width: 0;
+      min-height: 0;
     };
 
     --layout-flex-11: {
       -ms-flex: 11;
       -webkit-flex: 11;
       flex: 11;
+      min-width: 0;
+      min-height: 0;
     };
 
     --layout-flex-12: {
       -ms-flex: 12;
       -webkit-flex: 12;
       flex: 12;
+      min-width: 0;
+      min-height: 0;
     };
 
     /* alignment in cross axis */

--- a/test/index.html
+++ b/test/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html><!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+--><html><head>
+
+    <title>iron-flex-layout tests</title>
+
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+    <script src="../../web-component-tester/browser.js"></script>
+
+  </head>
+  <body>
+
+    <script>
+      WCT.loadSuites([
+        'iron-flex-layout.html',
+        'iron-flex-layout.html?dom=shadow'
+      ]);
+    </script>
+
+
+
+</body></html>

--- a/test/iron-flex-layout.html
+++ b/test/iron-flex-layout.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<!--
+@license
+Copyright (c) 2015 The Polymer Project Authors. All rights reserved.
+This code may only be used under the BSD style license found at http://polymer.github.io/LICENSE.txt
+The complete set of authors may be found at http://polymer.github.io/AUTHORS.txt
+The complete set of contributors may be found at http://polymer.github.io/CONTRIBUTORS.txt
+Code distributed by Google as part of the polymer project is also
+subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
+-->
+<html>
+
+<head>
+
+  <title>iron-flex-layout tests</title>
+
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+
+  <script src="../../web-component-tester/browser.js"></script>
+  <link rel="import" href="../../iron-flex-layout/iron-flex-layout.html">
+
+  <style is="custom-style">
+    .fixed-width {
+      width: 400px;
+    }
+
+    .fixed-height {
+      height: 400px;
+    }
+
+    .box {
+      width: 100px;
+      height: 100px;
+      background-color: orange;
+    }
+
+    .horizontal {
+      @apply(--layout-horizontal);
+    }
+
+    .vertical {
+      @apply(--layout-vertical);
+    }
+
+    .flex {
+      @apply(--layout-flex);
+    }
+  </style>
+
+</head>
+
+<body>
+
+  <test-fixture id="horizontal">
+    <template>
+      <section class="horizontal fixed-width">
+        <div class="flex box">box</div>
+        <div class="flex box">box</div>
+      </section>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="vertical">
+    <template>
+      <section class="vertical fixed-height">
+        <div class="flex box">box</div>
+        <div class="flex box">box</div>
+      </section>
+    </template>
+  </test-fixture>
+
+  <script>
+    suite('horizontal', function() {
+      var container, children;
+
+      var checkPositionAndSize = function(childWidth) {
+        var rect = container.getBoundingClientRect();
+        for (var i = 0; i < children.length; i++) {
+          var cRect = children[i].getBoundingClientRect();
+          assert.equal(cRect.width, childWidth, 'correct width');
+          assert.equal(cRect.left, rect.left + i * childWidth, 'correct left');
+        }
+      }
+
+      setup(function() {
+        container = fixture('horizontal');
+        children = Polymer.dom(container).children;
+      });
+
+      test('children are correctly positioned and sized', function() {
+        // container has width = 400px and 2 children, so each child shoud have width = 200px
+        checkPositionAndSize(200);
+      });
+
+      test('bigger content in a flex child does not affect position and size', function() {
+        var child = document.createElement('div');
+        child.style.width = '300px';
+        children[0].appendChild(child);
+        // even if first child has content with width = 300px,
+        // each child shoud still have width = 200px
+        checkPositionAndSize(200);
+      });
+
+      test('non-flex child handled', function() {
+        var child = document.createElement('div');
+        child.style.width = '300px';
+        container.appendChild(child);
+        // Added a child with width = 300px, so only 100px remain
+        // for the other 2 children (50px each).
+        checkPositionAndSize(50);
+      });
+
+    });
+
+    suite('vertical', function() {
+      var container, children;
+
+      var checkPositionAndSize = function(childHeight) {
+        var rect = container.getBoundingClientRect();
+        for (var i = 0; i < children.length; i++) {
+          var cRect = children[i].getBoundingClientRect();
+          assert.equal(cRect.height, childHeight, 'correct height');
+          assert.equal(cRect.top, rect.top + i * childHeight, 'correct top');
+        }
+      }
+
+      setup(function() {
+        container = fixture('vertical');
+        children = Polymer.dom(container).children;
+      });
+
+      test('children are correctly positioned and sized', function() {
+        checkPositionAndSize(200);
+      });
+
+      test('bigger content in a flex child does not affect position and size', function() {
+        var child = document.createElement('div');
+        child.style.height = '300px';
+        children[0].appendChild(child);
+
+        checkPositionAndSize(200);
+      });
+
+      test('non-flex child handled', function() {
+        var child = document.createElement('div');
+        child.style.height = '300px';
+        container.appendChild(child);
+
+        checkPositionAndSize(50);
+      });
+
+    });
+  </script>
+
+</body>
+
+</html>


### PR DESCRIPTION
Fixes #71 by setting `min-width` and `min-height` to the `flex` related mixins.
