### PR TITLE
Indent markdown list

### DIFF
--- a/iron-flex-layout.html
+++ b/iron-flex-layout.html
@@ -20,14 +20,14 @@ The layout class stylesheet provides a simple set of class-based flexbox rules, 
 let you specify layout properties directly in markup. You must include this file
 in every element that needs to use them.
 
-Sample use:
+  Sample use:
 
-    <link rel="import" href="../iron-flex-layout/iron-flex-layout-classes.html">
-    <style is="custom-style" include="iron-flex iron-flex-alignment"></style>
+      <link rel="import" href="../iron-flex-layout/iron-flex-layout-classes.html">
+      <style is="custom-style" include="iron-flex iron-flex-alignment"></style>
 
-    <div class="layout horizontal layout-start">
-      <div>cross axis start alignment</div>
-    </div>
+      <div class="layout horizontal layout-start">
+        <div>cross axis start alignment</div>
+      </div>
 
 2. [Custom CSS mixins](https://github.com/PolymerElements/iron-flex-layout/blob/master/iron-flex-layout.html).
 The mixin stylesheet includes custom CSS mixins that can be applied inside a CSS rule using the `@apply` function.


### PR DESCRIPTION
This should correct the numbering in the README, or at least give it a chance of being correct. Tedium may still mess it up, but at that point it *would* be a Tedium bug.