### PR TITLE
fix IE10 tests

### DIFF
--- a/iron-flex-layout-classes.html
+++ b/iron-flex-layout-classes.html
@@ -238,30 +238,35 @@ The following imports are available:
        * multi-line alignment in main axis.
        */
       .layout.start-aligned {
+        -ms-flex-line-pack: start;  /* IE10 */
         -ms-align-content: flex-start;
         -webkit-align-content: flex-start;
         align-content: flex-start;
       }
 
       .layout.end-aligned {
+        -ms-flex-line-pack: end;  /* IE10 */
         -ms-align-content: flex-end;
         -webkit-align-content: flex-end;
         align-content: flex-end;
       }
 
       .layout.center-aligned {
+        -ms-flex-line-pack: center;  /* IE10 */
         -ms-align-content: center;
         -webkit-align-content: center;
         align-content: center;
       }
 
       .layout.between-aligned {
+        -ms-flex-line-pack: justify;  /* IE10 */
         -ms-align-content: space-between;
         -webkit-align-content: space-between;
         align-content: space-between;
       }
 
       .layout.around-aligned {
+        -ms-flex-line-pack: distribute;  /* IE10 */
         -ms-align-content: space-around;
         -webkit-align-content: space-around;
         align-content: space-around;

--- a/iron-flex-layout.html
+++ b/iron-flex-layout.html
@@ -296,30 +296,35 @@ A complete [guide](https://elements.polymer-project.org/guides/flex-layout) to `
     /* multi-line alignment in main axis */
 
     --layout-start-aligned: {
+      -ms-flex-line-pack: start;  /* IE10 */
       -ms-align-content: flex-start;
       -webkit-align-content: flex-start;
       align-content: flex-start;
     };
 
     --layout-end-aligned: {
+      -ms-flex-line-pack: end;  /* IE10 */
       -ms-align-content: flex-end;
       -webkit-align-content: flex-end;
       align-content: flex-end;
     };
 
     --layout-center-aligned: {
+      -ms-flex-line-pack: center;  /* IE10 */
       -ms-align-content: center;
       -webkit-align-content: center;
       align-content: center;
     };
 
     --layout-between-aligned: {
+      -ms-flex-line-pack: justify;  /* IE10 */
       -ms-align-content: space-between;
       -webkit-align-content: space-between;
       align-content: space-between;
     };
 
     --layout-around-aligned: {
+      -ms-flex-line-pack: distribute;  /* IE10 */
       -ms-align-content: space-around;
       -webkit-align-content: space-around;
       align-content: space-around;


### PR DESCRIPTION
Tests are currently broken because `align-content` isn't a thing in IE10. According to http://zomigi.com/blog/flexbox-syntax-for-ie-10/, it should be `-ms-flex-line-pack`, not `-ms-align-content`.