### PR TITLE
Revert "apply `.layout` will be horizontal(row) by default."

### DIFF
--- a/iron-flex-layout-classes.html
+++ b/iron-flex-layout-classes.html
@@ -35,7 +35,8 @@ The following imports are available:
 <dom-module id="iron-flex">
   <template>
     <style>
-      .layout {
+      .layout.horizontal,
+      .layout.vertical {
         display: -ms-flexbox;
         display: -webkit-flex;
         display: flex;


### PR DESCRIPTION
Reverts PolymerElements/iron-flex-layout#94 -- if you're using `layout` as a standalone class, this PR will break you