### PR TITLE
from polymer to Polymer in 2.0-preview

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,14 +18,14 @@
     "url": "git://github.com/PolymerElements/iron-flex-layout.git"
   },
   "dependencies": {
-    "polymer": "polymer/polymer#^2.0.0-rc.1"
+    "polymer": "Polymer/polymer#^2.0.0-rc.1"
   },
   "devDependencies": {
     "test-fixture": "PolymerElements/test-fixture#^3.0.0-rc.1",
     "web-component-tester": "Polymer/web-component-tester#^6.0.0-prerelease.6",
     "webcomponentsjs": "webcomponents/webcomponentsjs#^1.0.0-rc.1",
-    "iron-component-page": "polymerelements/iron-component-page#2.0-preview",
-    "iron-demo-helpers": "polymerelements/iron-demo-helpers#2.0-preview"
+    "iron-component-page": "PolymerElements/iron-component-page#2.0-preview",
+    "iron-demo-helpers": "PolymerElements/iron-demo-helpers#2.0-preview"
   },
   "ignore": [],
   "variants": {
@@ -37,8 +37,8 @@
         "test-fixture": "PolymerElements/test-fixture#^1.0.0",
         "webcomponentsjs": "webcomponents/webcomponentsjs#^0.7.0",
         "web-component-tester": "Polymer/web-component-tester#^4.0.0",
-        "iron-component-page": "polymerelements/iron-component-page#^1.0.0",
-        "iron-demo-helpers": "polymerelements/iron-demo-helpers#^1.0.0"
+        "iron-component-page": "PolymerElements/iron-component-page#^1.0.0",
+        "iron-demo-helpers": "PolymerElements/iron-demo-helpers#^1.0.0"
       }
     }
   },


### PR DESCRIPTION
This pull request wants to make this Polymer element consistent with the majority of other Polymer elements in the 2.0-preview branch. The uppercase version "Polymer" and "PolymerElements" are closer to real name of the github project name, like presented in the git URL.

The use of mixed case does not seem to have an effect on bower and JavaScript projects. But other languages like Java are more picky and would benefit from consistency.

I fixed this in the  "2.0-preview" branch of this element, because it would be very nice to have this cleaned up and consistent in 2.0 release. I have manually checked 66 elements that have a "2.0-preview" branch. 56 are ok. This element is one of 10 which has these small differences.

I'm mostly concerned with the bower "Main" dependencies, but as I have changed this file already I also fixed this in the devDependencies

This pull request is a manual follow up of PolymerLabs/tedium#47 and PolymerLabs/tedium#48 which try to do this in an automated way, but are stuck.
