### PR TITLE
Update iron-flex-layout-classes.js

### DIFF
--- a/iron-flex-layout-classes.js
+++ b/iron-flex-layout-classes.js
@@ -39,7 +39,7 @@ The following imports are available:
 */
 
 const template = html`
-/* Most common used flex styles*/
+<!-- Most common used flex styles -->
 <dom-module id="iron-flex">
   <template>
     <style>
@@ -116,7 +116,7 @@ const template = html`
     </style>
   </template>
 </dom-module>
-/* Basic flexbox reverse styles */
+<!-- Basic flexbox reverse styles -->
 <dom-module id="iron-flex-reverse">
   <template>
     <style>
@@ -147,7 +147,7 @@ const template = html`
     </style>
   </template>
 </dom-module>
-/* Flexbox alignment */
+<!-- Flexbox alignment -->
 <dom-module id="iron-flex-alignment">
   <template>
     <style>
@@ -286,7 +286,7 @@ const template = html`
     </style>
   </template>
 </dom-module>
-/* Non-flexbox positioning helper styles */
+<!-- Non-flexbox positioning helper styles -->
 <dom-module id="iron-flex-factors">
   <template>
     <style>


### PR DESCRIPTION
Inside HTML template (html ``) there are comments for CSS (/ * * /).

Comment markup has been changed to HTML format <! - ->

In the previous way, after the build the comments were added to the index as text and GoogleBot indexed the description as follows:

"Most common used flex styles * / / * Basic flexbox reverse styles * / / * Flexbox alignment * / / * Non-flexbox positioning helper styles * / ..."

Hope this helps
Thanks